### PR TITLE
Watch video feature

### DIFF
--- a/playlist-editor/src/components/PlaylistVideo.svelte
+++ b/playlist-editor/src/components/PlaylistVideo.svelte
@@ -16,9 +16,19 @@
   function deleteVideo(_: Event) {
     dispatch("delete", video);
   }
+
+  function watchVideo(event: Event) {
+    dispatch("watch", { video, watched: (event.target as HTMLInputElement).checked });
+  }
 </script>
 
-<div class="playlist-video" class:is-active={active}>
+<div class="playlist-video" class:is-active={active}  class:watched={video.isWatched}>
+  <!-- checkbox for watched  -->
+  <div class="watched">
+    <input type="checkbox" bind:checked={video.isWatched} on:change={watchVideo} />
+  </div>
+
+
   {#if !disableThumbnails}
     <img
       alt={video.title}
@@ -48,6 +58,10 @@
 
   .playlist-video.is-active {
     background-color: #3273dc;
+    color: #fff;
+  }  
+  .playlist-video.watched {
+    background-color: #52a451; 
     color: #fff;
   }
 
@@ -82,5 +96,12 @@
     justify-content: center;
     align-items: center;
     margin-left: 10px;
+  }
+
+  .watched {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    margin-right: 10px;
   }
 </style>

--- a/playlist-editor/src/services/video-service.ts
+++ b/playlist-editor/src/services/video-service.ts
@@ -78,10 +78,15 @@ class VideoService {
   async generatePlaylist(videoIds?: string[], title?: string) {
     const id = await window.generatePlaylistId();
     const date = new Date();
+    let watchedInfo = [];
+    if (videoIds) {
+      watchedInfo = new Array(videoIds.length).fill(false);
+    }
     return {
       id,
       title: title ?? date.toLocaleString(),
       videos: videoIds || [],
+      watchedInfo: watchedInfo,
       timestamp: date.getTime(),
     };
   }

--- a/playlist-editor/src/services/video-service.ts
+++ b/playlist-editor/src/services/video-service.ts
@@ -19,6 +19,7 @@ class VideoService {
     let title = "";
     let channel = "";
     let sessionVideoData = sessionStorage.getItem(videoId);
+    let isWatched = false;
     if (!sessionOnly && !sessionVideoData) {
       try {
         const res = await fetch(
@@ -27,15 +28,16 @@ class VideoService {
         const json = await res.json();
         title = json.title;
         channel = json.author_name;
-        sessionStorage.setItem(videoId, JSON.stringify({ title, channel }));
+        sessionStorage.setItem(videoId, JSON.stringify({ title, channel,isWatched }));
       } catch (e) {
         console.log(e);
       }
     } else if (sessionVideoData) {
-      ({ title, channel } = JSON.parse(sessionVideoData));
+      ({ title, channel,isWatched } = JSON.parse(sessionVideoData));
     } else {
       title = "";
       channel = "";
+      isWatched = false;
     }
     return {
       id: window.videoIdCount++,
@@ -44,6 +46,7 @@ class VideoService {
       title,
       channel,
       thumbnailUrl: this.getVideoThumbnailUrl(videoId),
+      isWatched,
     };
   }
 

--- a/playlist-editor/src/types/model.d.ts
+++ b/playlist-editor/src/types/model.d.ts
@@ -5,6 +5,7 @@ export interface Video {
   title: string;
   channel: string;
   thumbnailUrl: string;
+  isWatched: boolean;
 }
 
 export interface PlaylistExport {
@@ -18,6 +19,7 @@ export interface Playlist {
   title: string;
   loadedVideos?: Video[];
   videos: string[];
+  watchedInfo: boolean[];
   /** Date created */
   timestamp: number;
   saved?: boolean;

--- a/playlist-editor/src/types/model.d.ts
+++ b/playlist-editor/src/types/model.d.ts
@@ -12,6 +12,7 @@ export interface PlaylistExport {
   title: string;
   videos: string[];
   timestamp: number;
+  watchedInfo: boolean[];
 }
 
 export interface Playlist {


### PR DESCRIPTION
Hi, 

As a user who personally finds this plugin very useful for organizing my YouTube playlists, especially lecture series, I fell the need of being able to track where I left off. Therefore, I've added a feature to mark videos as watched, enhancing the usability of the plugin.

Changes Made:
- Added a checkbox to each video component in the playlist editor, allowing users to mark videos as watched.
- Modified the "Save the Playlist" button functionality to also save the watched status of the videos.
- Toggle the background color of the video component based on its watched status, providing visual feedback to users.

Yusuf

PS: 
- I only partially tested the plugin after the changes.
- I am not experienced in Svelte or web dev in general. 